### PR TITLE
Changed conanfile requires to use new boost naming convention

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -19,8 +19,8 @@ class YAMLCppConan(ConanFile):
     options = {"shared": [True, False]}
     default_options = "shared=False"
     requires = (
-        "Boost.Smart_Ptr/[>=1.65.1]@bincrafters/stable", 
-        "Boost.Iterator/[>=1.65.1]@bincrafters/stable"
+        "boost_smart_ptr/[>=1.65.1]@bincrafters/stable",
+        "boost_iterator/[>=1.65.1]@bincrafters/stable"
     )
 
     def source(self):


### PR DESCRIPTION
Package is broken now that the old boost naming conventions have been deprecated. Just a small fix to use the new ones.