### PR TITLE
Missing copy LICENSE file

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -49,7 +49,7 @@ class YAMLCppConan(ConanFile):
         cmake.build()
 
     def package(self):
-        self.copy(pattern="LICENSE.md", dst="licenses", src=self.source_subfolder)
+        self.copy(pattern="LICENSE", dst="licenses", src=self.source_subfolder)
         cmake = self.configure_cmake()
         cmake.install()
 


### PR DESCRIPTION
The `LICENSE` file of yaml-cpp is no extension.

```bash
$ tar -tzf yaml-cpp-yaml-cpp-0.6.2.tar.gz  | grep  yaml-cpp-yaml-cpp-0.6.2/LICENSE
yaml-cpp-yaml-cpp-0.6.2/LICENSE
```