### PR TITLE
Define cppinfo.builddirs

### DIFF
--- a/conanfile.py
+++ b/conanfile.py
@@ -55,6 +55,7 @@ class YAMLCppConan(ConanFile):
 
     def package_info(self):
         self.cpp_info.libs = tools.collect_libs(self)
+        self.cpp_info.builddirs = ["lib/cmake"]
         if self.settings.os == "Linux":
             self.cpp_info.libs.append('m')
         if self.settings.compiler == 'Visual Studio':


### PR DESCRIPTION
this is required in order to allow cmake_paths generator to work properly